### PR TITLE
Export ITE condition expression via the `exp` function

### DIFF
--- a/bap/lib/bindings.ml
+++ b/bap/lib/bindings.ml
@@ -974,6 +974,7 @@ struct
       | Bil.UnOp (_,x)
       | Bil.Cast (_,_,x)
       | Bil.Let (_,_,x)
+      | Bil.Ite (x,_,_)
       | Bil.Extract (_,_,x) -> Some x
       | _ -> None
 


### PR DESCRIPTION
Previously, while the true and false branches of ITE expressions were exposed via the `lhs` and `rhs` functions, the actual condition was exposed nowhere. This PR exposes it through the `exp` function.