### PR TITLE
bap.h: add "extern C" for C++

### DIFF
--- a/bap/stub_generator/generate.ml
+++ b/bap/stub_generator/generate.ml
@@ -16,11 +16,18 @@ let generate dirname =
       (Cstubs_inverted.write_c ~prefix) stubs;
 
     fprintf (formatter_of_out_channel h_fd)
-      "#include <stdint.h>
-       #include <stdlib.h>
+"#include <stdint.h>
+#include <stdlib.h>
 
-      void bap_init(int argc, const char *argv[]);
-%a"
+#ifdef __cplusplus
+extern \"C\" {
+#endif
+
+void bap_init(int argc, const char *argv[]);
+%a
+#ifdef __cplusplus
+}
+#endif@\n%!"
     (Cstubs_inverted.write_c_header ~prefix) stubs;
 
   end;


### PR DESCRIPTION
Fix #10.