### PR TITLE
bap.h: add cstdbool for _Bool type

### DIFF
--- a/bap/stub_generator/generate.ml
+++ b/bap/stub_generator/generate.ml
@@ -20,6 +20,10 @@ let generate dirname =
 #include <stdlib.h>
 
 #ifdef __cplusplus
+#ifndef __bool_true_false_are_defined
+#include <cstdbool>
+#endif
+
 extern \"C\" {
 #endif
 


### PR DESCRIPTION
There is no `_Bool` type in C++ and hence this PR adds `cstdbool` to bap.h. It should work for the mainstream compilers.

I would have added it to the last PR but I had cstdbool in my main program...