### PR TITLE
fixes the lift_insn example

### DIFF
--- a/bap/stub/init.c
+++ b/bap/stub/init.c
@@ -5,6 +5,7 @@ void bap__stdio_init(FILE *, FILE *, FILE *);
 
 struct bap_parameters_t;
 int bap__main_init(struct bap_parameters_t *);
+const char * bap_error_get(void);
 
 int bap_init2(int argc, const char **argv, struct bap_parameters_t *pars) {
     caml_startup((char **)argv);
@@ -13,5 +14,8 @@ int bap_init2(int argc, const char **argv, struct bap_parameters_t *pars) {
 }
 
 void bap_init(int argc, const char **argv) {
-    bap_init2(argc,argv,NULL);
+    if (bap_init2(argc,argv,NULL)) {
+        fprintf(stderr, "failed to initialize BAP: %s\n", bap_error_get());
+        exit(1);
+    }
 }

--- a/examples/lift_insn.c
+++ b/examples/lift_insn.c
@@ -16,7 +16,7 @@ int main(int argc, const char **argv) {
     }
 
     // all OCaml values are visible as opaque structures in C
-    bap_word_t *base = bap_word_of_int(32,0x80000);
+    bap_word_t *base = bap_word_of_int(64,0x80000);
 
     bap_memory_t *mem = bap_memory_create(BAP_ENDIAN_LITTLE,
                                           base, data, sizeof(data));


### PR DESCRIPTION
The example was buggy as the size of the pointer was specified incorrectly. It was acceptable before but is no longer tolerated
after we enabled [interworking][1] (several architectures in the same binary).

resolves #19

[1]: https://github.com/BinaryAnalysisPlatform/bap/pull/1226