### PR TITLE
adds support for the `requires` keyword introduced with C++20

### DIFF
--- a/bap/stub_generator/generate.ml
+++ b/bap/stub_generator/generate.ml
@@ -16,12 +16,14 @@ let generate dirname =
       (Cstubs_inverted.write_c ~prefix) stubs;
 
     fprintf (formatter_of_out_channel h_fd)
-      "#include <stdint.h>
+      "
+#include <stdint.h>
 #include <stdlib.h>
 
 #ifdef __cplusplus
-#if __cplusplus >= 202002L
+#if __cplusplus > 201703L
 #define requires requires_
+#define BAP_RENAMES_REQUIRES
 #endif
 #ifndef __bool_true_false_are_defined
 #include <cstdbool>
@@ -35,7 +37,8 @@ void bap_init(int argc, const char *argv[]);
 int bap_init2(int argc, const char *argv[], struct bap_parameters_t *pars);
 
 #ifdef __cplusplus
-#if __cplusplus >= 202002L
+
+#ifdef BAP_RENAMES_REQUIRES
 #undef requires
 #endif
 

--- a/bap/stub_generator/generate.ml
+++ b/bap/stub_generator/generate.ml
@@ -16,10 +16,13 @@ let generate dirname =
       (Cstubs_inverted.write_c ~prefix) stubs;
 
     fprintf (formatter_of_out_channel h_fd)
-"#include <stdint.h>
+      "#include <stdint.h>
 #include <stdlib.h>
 
 #ifdef __cplusplus
+#if __cplusplus >= 202002L
+#define requires requires_
+#endif
 #ifndef __bool_true_false_are_defined
 #include <cstdbool>
 #endif
@@ -32,9 +35,13 @@ void bap_init(int argc, const char *argv[]);
 int bap_init2(int argc, const char *argv[], struct bap_parameters_t *pars);
 
 #ifdef __cplusplus
+#if __cplusplus >= 202002L
+#undef requires
+#endif
+
 }
 #endif@\n%!"
-    (Cstubs_inverted.write_c_header ~prefix) stubs;
+      (Cstubs_inverted.write_c_header ~prefix) stubs;
 
   end;
   close_out h_fd;


### PR DESCRIPTION
When C++20 is enabled we rewrite `requires` to `requires_`.

Fixes #22 